### PR TITLE
Remove stage reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@ ECMAScript Proposal, specs, and reference implementation for `Object.prototype.p
 
 Spec drafted by [@Aleen](https://github.com/aleen42).
 
-This proposal is currently [stage 1](https://github.com/tc39/proposals/) of the [process](https://tc39.github.io/process-document/).
-
 ### Motivation
 
 - To operate an object convenient by picking or omitting its properties, describe in [the group](https://es.discourse.group/t/object-prototype-pick-object-prototype-omit/515).


### PR DESCRIPTION
Proposals need a champion to be at a stage, and committee consensus to advance beyond stage 0.